### PR TITLE
comparing first 6 letters of $key to a 5 character string

### DIFF
--- a/modules/monitoring/models/host.php
+++ b/modules/monitoring/models/host.php
@@ -1060,7 +1060,7 @@ class Host_Model extends BaseHost_Model {
 		$public = array();
 
 		foreach ($all_variables as $key => $value) {
-			if (substr($key, 0, 6) !== 'OP5H_') {
+			if (substr($key, 0, 5) !== 'OP5H_') {
 				$public[$key] = $value;
 			}
 		}

--- a/modules/monitoring/models/service.php
+++ b/modules/monitoring/models/service.php
@@ -959,7 +959,7 @@ class Service_Model extends BaseService_Model {
         $public = array();
 
         foreach ($all_variables as $key => $value) {
-            if (substr($key, 0, 6) !== 'OP5H_') {
+            if (substr($key, 0, 5) !== 'OP5H_') {
                 $public[$key] = $value;
             }
         }


### PR DESCRIPTION
OP5H_ custom variables are not being correctly hidden because the comparison with $key is incorrect.